### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/gogomes/fb5bfc1c-3952-4316-b38e-99f8d56b7033/e5067199-a026-4096-800e-fa0f60195eb3/_apis/work/boardbadge/180fe51f-754a-4550-810b-aa3c6be2aea7)](https://dev.azure.com/gogomes/fb5bfc1c-3952-4316-b38e-99f8d56b7033/_boards/board/t/e5067199-a026-4096-800e-fa0f60195eb3/Microsoft.RequirementCategory)
 ### Purpose
 This repo serves to test conditional GitHub Status checks based on path to prevent intesnive CI builds when changing stuff like RFCs or docs. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/gogomes/fb5bfc1c-3952-4316-b38e-99f8d56b7033/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.